### PR TITLE
fix: resolve project audit issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ EMAIL_PORT=993
 # Web3Forms API Key
 WEB3FORMS_API_KEY="your-web3forms-api-key"
 
+# Microsoft Clarity
+PUBLIC_CLARITY_ID="your-clarity-project-id"
+
 # Supabase Configuration
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_ANON_KEY="your-supabase-anon-key"

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import tailwind from "@astrojs/tailwind";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import { remarkReadingTime } from "./remark-reading-time.mjs";
+import { remarkGifPassthrough } from "./remark-gif-passthrough.mjs";
 import netlify from "@astrojs/netlify";
 import icon from "astro-icon";
 import partytown from "@astrojs/partytown";
@@ -10,7 +11,6 @@ import clarityIntegration from 'astro-microsoft-clarity-integration';
 import react from "@astrojs/react";
 import rehypePrettyCode from "rehype-pretty-code";
 
-import db from "@astrojs/db";
 
 export default defineConfig({
   site: "https://developingdvlpr.com",
@@ -34,16 +34,7 @@ export default defineConfig({
         ],
       ],
     }),
-    sitemap({
-      i18n: {
-        defaultLocale: 'en',
-        locales: {
-          en: 'en-US', // The `defaultLocale` value must be present as a key in `locales`
-          es: 'es-ES',
-          fr: 'fr-CA',
-        },
-      },
-    }),
+    sitemap(),
     icon({
       include: {
         bx: ["*"],
@@ -57,7 +48,7 @@ export default defineConfig({
       },
     }),
     clarityIntegration({
-      projectId: 's7v3rqipza',  // Required: Replace with your Clarity project ID
+      projectId: import.meta.env.PUBLIC_CLARITY_ID,
       enabled: true,                  // Optional: Enable the integration (defaults to true)
       scriptStage: 'head-inline',     // Optional: Set scriptStage to 'head-inline', 'body-inline'
       debug: false,                   // Optional: Enable debug (set to true if you want to log script injections)
@@ -105,7 +96,7 @@ export default defineConfig({
     ],
   },
   markdown: {
-    remarkPlugins: [remarkReadingTime],
+    remarkPlugins: [remarkReadingTime, remarkGifPassthrough],
     syntaxHighlight: false,
     rehypePlugins: [
       [

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,15 +1,10 @@
 [build]
-  command = "astro build"
+  command = "astro build --remote"
   publish = "dist"
 
 [build.environment]
   NPM_VERSION = "9.8.1"
   # NODE_VERSION = "20"
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
 
 [functions]
   node_bundler = "esbuild"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "test:all": "npm run test:run && npm run test:e2e"
   },
   "dependencies": {
-    "@astrojs/db": "^0.16.1",
-    "@astrojs/mdx": "^4.0.6",
+"@astrojs/mdx": "^4.0.6",
     "@astrojs/netlify": "^6.3.4",
     "@astrojs/partytown": "^2.1.4",
     "@astrojs/react": "^4.4.2",
@@ -46,11 +45,9 @@
     "boxicons": "^2.1.4",
     "mdast-util-to-string": "^4.0.0",
     "nodemailer": "^6.10.0",
-    "npm-check": "^6.0.1",
     "pinia": "^2.3.0",
     "reading-time": "^1.5.0",
     "rehype-pretty-code": "^0.14.3",
-    "reload": "^3.3.0",
     "sharp": "^0.33.5",
     "shiki": "^4.0.2",
     "simple-icons-astro": "^14.3.0",
@@ -78,7 +75,9 @@
     "globals": "^15.14.0",
     "happy-dom": "^20.8.3",
     "tailwind-merge": "^3.5.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "npm-check": "^6.0.1",
+    "reload": "^3.3.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.60.0",

--- a/remark-gif-passthrough.mjs
+++ b/remark-gif-passthrough.mjs
@@ -1,0 +1,21 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Remark plugin that converts remote .gif image nodes to raw HTML <img> tags,
+ * bypassing Astro's image optimizer (which fails to inferSize on remote GIFs).
+ */
+export function remarkGifPassthrough() {
+  return function (tree) {
+    visit(tree, 'image', (node, index, parent) => {
+      const src = node.url || '';
+      if (src.startsWith('http') && src.endsWith('.gif')) {
+        const alt = node.alt || '';
+        const html = `<img src="${src}" alt="${alt}" />`;
+        parent.children.splice(index, 1, {
+          type: 'html',
+          value: html,
+        });
+      }
+    });
+  };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -214,22 +214,17 @@ export async function getViewCount(slug: string): Promise<number> {
  */
 export async function getAllViewCounts(): Promise<Record<string, number>> {
   try {
-    // Single query to get counts for all slugs
-    // Uses SQL GROUP BY to count distinct device_ids per slug
     const { data, error } = await supabase
-      .from('post_views')
-      .select('post_slug')
-      .order('post_slug');
+      .rpc('get_all_view_counts');
 
     if (error) {
       console.error('Error fetching view counts:', error);
       return {};
     }
 
-    // Count unique device_ids per slug
     const viewCounts: Record<string, number> = {};
-    data?.forEach(item => {
-      viewCounts[item.post_slug] = (viewCounts[item.post_slug] || 0) + 1;
+    data?.forEach((item: { slug: string; count: number }) => {
+      viewCounts[item.slug] = item.count;
     });
 
     return viewCounts;


### PR DESCRIPTION
## Summary

- **Remove SPA redirect** from `netlify.toml` (`/* → /index.html`) that was breaking SSR routing — this was likely the root cause of the recent Netlify deployment issues
- **Align build command** — `netlify.toml` now uses `astro build --remote` to match `package.json`
- **Remove unused `@astrojs/db`** integration and import (view tracking runs entirely on Supabase)
- **Fix `getAllViewCounts()`** — replaced full table scan + client-side counting with the existing `get_all_view_counts` RPC (SQL-level aggregation, scales properly)
- **Clarity project ID** moved from hardcoded string to `PUBLIC_CLARITY_ID` env var
- **Remove unused i18n locales** (`es`, `fr`) from sitemap config — no translated content exists
- **Move `npm-check` and `reload`** from `dependencies` to `devDependencies`
- **Add `remark-gif-passthrough` plugin** to prevent Astro image optimizer from failing on remote `.gif` URLs

## Test plan

- [ ] Deploy to Netlify preview and verify SSR routes load correctly (especially blog post pages)
- [ ] Confirm `PUBLIC_CLARITY_ID` env var is set in Netlify environment settings
- [ ] Verify blog post view counts still increment and display correctly
- [ ] Confirm no build errors related to removed `@astrojs/db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)