### PR TITLE
fix(a11y): fix skip-to-main-content link visibility in navbar (#322)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -120,11 +120,8 @@ const makeTitle = title || "Nerando's Portfolio";
   </head>
   <body
     class='bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 transition-colors duration-200'>
-    <a href='#main-content' class='skip-link'>Skip to main content</a>
     <Navbar />
-    <div id='main-content'>
-      <slot />
-    </div>
+    <slot />
     <Footer />
     <style is:global>
       /* Improve Page speed */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -120,8 +120,11 @@ const makeTitle = title || "Nerando's Portfolio";
   </head>
   <body
     class='bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 transition-colors duration-200'>
+    <a href='#main-content' class='skip-link'>Skip to main content</a>
     <Navbar />
-    <slot />
+    <main id='main-content'>
+      <slot />
+    </main>
     <Footer />
     <style is:global>
       /* Improve Page speed */


### PR DESCRIPTION
The skip-to-main-content link was always visible in the page header. Restored the `a.skip-link` anchor (visually hidden via `global.css` until focused) and replaced the `div#main-content` wrapper with a semantic `<main id="main-content">` landmark around the page slot.