### PR TITLE
Vue 3 Fundamentals: add Parts 4 & 5, fix series numbering in Vue Router article

### DIFF
--- a/src/content/blog/Finding-Your-Route-Mastering-Vue-Router.md
+++ b/src/content/blog/Finding-Your-Route-Mastering-Vue-Router.md
@@ -79,7 +79,7 @@ aiOptimization: {
 
 ## Finding Your Route: Mastering Vue Router
 
-*Part 4 of the **Vue 3 Fundamentals** series — adding client-side routing to your Vue 3 app.*
+*Part 5 of the **Vue 3 Fundamentals** series — adding client-side routing to your Vue 3 app.*
 
 ---
 
@@ -354,7 +354,7 @@ const cityId = computed(() => route.params.id)
 
 ## Your Turn
 
-Before moving to Article 5, try this:
+Before moving to Article 6, try this:
 
 1. Add a named route for `/city/:id` and navigate to it from a list using `router.push({ name: 'city', params: { id } })`
 2. Add a `query` param like `?unit=C` and read it with `route.query.unit`
@@ -374,4 +374,4 @@ You know how to move between pages. Now let's build what lives on them.
 
 ---
 
-*This is Part 4 of the Vue 3 Fundamentals series. Sources: [Vue Router Official Docs](https://router.vuejs.org/guide/), [Vue Router — Dynamic Route Matching](https://router.vuejs.org/guide/essentials/dynamic-matching.html).*
+*This is Part 5 of the Vue 3 Fundamentals series. Sources: [Vue Router Official Docs](https://router.vuejs.org/guide/), [Vue Router — Dynamic Route Matching](https://router.vuejs.org/guide/essentials/dynamic-matching.html).*

--- a/src/content/blog/Finding-Your-Route-Mastering-Vue-Router.md
+++ b/src/content/blog/Finding-Your-Route-Mastering-Vue-Router.md
@@ -1,0 +1,377 @@
+---
+draft: false
+seoTitle: "Finding Your Route: Mastering Vue Router | Nerando Johnson"
+seoDescription: "Learn how to add client-side routing to your Vue 3 app with Vue Router — route setup, dynamic segments, navigation guards, and the router-link component."
+author: "Nerando Johnson"
+title: "Finding Your Route: Mastering Vue Router"
+snippet: "A single-page app without routing is just a page. In this article we wire up Vue Router, define routes, navigate with router-link and useRouter, and handle dynamic segments — so your Vue app can go anywhere."
+image: {
+    src: "/images/blog_covers/Vue3 Image.png",
+    alt: "Vue.js logo on a light blue background with geometric shapes"
+}
+publishDate: "2026-04-22 00:00"
+category: "Vue, JavaScript, Tutorials"
+tags: [vue3, javascript, frontend, tutorial, vue-router, composition-api]
+keywords: [Vue Router tutorial, Vue 3 routing, router-link, useRouter, useRoute, dynamic routes, navigation guards, Vue 3 SPA routing, Vue Router setup, Vue 3 tutorial]
+series:
+  name: "Vue 3 Fundamentals"
+  order: 5
+
+# GEO-Enhanced Fields
+schema: {
+  type: "TechArticle",
+  about: "Client-side routing in Vue 3 using Vue Router — setup, dynamic segments, and navigation",
+  genre: "Educational Tutorial",
+  educationalLevel: "Beginner",
+  teaches: ["Vue Router Installation", "Route Definition", "router-link", "useRouter", "useRoute", "Dynamic Route Segments", "Navigation Guards"],
+  audience: {
+    type: "ProfessionalAudience",
+    audienceType: "Frontend Developers and JavaScript Learners"
+  }
+}
+
+entities: {
+  primary: ["Vue.js", "Vue 3", "Vue Router"],
+  secondary: ["router-link", "router-view", "useRouter", "useRoute", "Dynamic Segments", "Navigation Guards"],
+  people: ["Evan You"],
+  organizations: ["Vue.js Core Team"],
+  tools: ["Vue 3", "Vue Router", "Vite", "VS Code", "Volar"],
+  concepts: ["Client-Side Routing", "Single-Page Application", "Dynamic Route Segments", "Programmatic Navigation", "Navigation Guards", "Nested Routes"]
+}
+
+contentStructure: {
+  type: "Conceptual + Step-by-Step Tutorial",
+  difficulty: "Beginner",
+  timeToComplete: "10-12 minutes read",
+  prerequisites: ["Basic HTML", "Basic JavaScript", "Article 2 — Your First Vue 3 App", "Article 3 — Reactivity in Vue 3"],
+  outcomes: ["Install and configure Vue Router in a Vue 3 project", "Define static and dynamic routes", "Navigate with router-link and useRouter", "Read route params with useRoute", "Protect routes with navigation guards"]
+}
+
+semanticContext: {
+  topic: "Adding client-side routing to a Vue 3 application with Vue Router",
+  subtopics: ["createRouter and createWebHistory", "route definition objects", "router-view", "router-link", "useRouter push and replace", "useRoute params", "beforeEach guards"],
+  relatedConcepts: ["React Router", "Next.js App Router", "History API", "SPA Navigation", "URL Parameters"],
+  practicalApplication: true
+}
+
+citationMetadata: {
+  citableAs: "Johnson, N. (2026). Finding Your Route: Mastering Vue Router",
+  lastReviewed: "2026-04-15",
+  version: "1.0",
+  originalPublisher: "Nerando Johnson's Blog"
+}
+
+aiOptimization: {
+  summaryPrompt: "This article introduces Vue Router to beginners building Vue 3 apps. It covers installation, defining a route config, adding router-view to the app shell, navigating with router-link and useRouter, reading dynamic segments with useRoute, and adding a simple beforeEach navigation guard.",
+  keyTakeaways: [
+    "Vue Router is the official routing library for Vue 3 and turns a single-page app into a multi-view experience",
+    "Routes are defined as an array of objects mapping path strings to components",
+    "router-view is the outlet where matched components render; router-link replaces anchor tags for navigation",
+    "useRouter gives programmatic navigation (push, replace, back); useRoute exposes the current route's params and query",
+    "Dynamic segments like /city/:id let one route handle many URLs — the param is read from useRoute().params",
+    "Navigation guards like beforeEach run before every route change and can redirect or cancel navigation"
+  ],
+  technicalDepth: "low",
+  codeExamples: true
+}
+---
+
+
+## Finding Your Route: Mastering Vue Router
+
+*Part 4 of the **Vue 3 Fundamentals** series — adding client-side routing to your Vue 3 app.*
+
+---
+
+A single-page app without routing is just a page.
+
+You can build a lot with one view — but the moment your app needs a home screen, a detail view, a settings panel, or a 404 page, you need routing. Routing is what transforms a component tree into a navigable application.
+
+Vue Router is Vue's official solution. It's tightly integrated with Vue's reactivity system, plays nicely with `<script setup>`, and gives you everything you need — from simple path matching to dynamic segments to navigation guards — without pulling in a third-party library.
+
+Let's wire it up.
+
+---
+
+## What Vue Router Does
+
+<img src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExM2FqcHQza3VmMWJtNWt3azNmNTdxNDkzeHQya2YzNGd5cTZtZm04ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1oGXIfkeF4P4w3zPxk/giphy.gif" alt="Finding the right path" width="960" />
+
+In a traditional multi-page site, clicking a link sends a new HTTP request and the browser loads a fresh HTML page. In a single-page app, the page never reloads. Vue Router intercepts navigation, matches the URL to a route config, and renders the matching component — all in the browser.
+
+The URL still changes. The back button still works. Deep links still work. It just happens entirely on the client.
+
+---
+
+## Installing Vue Router
+
+<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzU4MnFnajU1Z292dWptNnpkdjZtaTJ6ZHcxYWF1cG96Y3dmMGQzayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oDyDSmr7StLCBKucHM/giphy.gif" alt="Setting up the tools" width="960" />
+
+If you scaffolded your project with `create-vue` and selected Vue Router during setup, it's already configured. If not, add it now:
+
+```bash
+npm install vue-router@4
+```
+
+Then create your router file at `src/router/index.js`:
+
+```js
+import { createRouter, createWebHistory } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+import AboutView from '../views/AboutView.vue'
+
+const routes = [
+  { path: '/', component: HomeView },
+  { path: '/about', component: AboutView },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router
+```
+
+And register it in `src/main.js`:
+
+```js
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(router).mount('#app')
+```
+
+Two things to notice:
+- `createWebHistory()` uses the HTML5 History API — clean URLs like `/about` instead of `/#/about`
+- `.use(router)` makes Vue Router available everywhere in the app
+
+---
+
+## `router-view`: The Outlet
+
+<img src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnVxYnlwYjRhZWI1aTdncHJoZmFob3VqcXpzcmkyZmNud2FwMWZtcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ge91zAgmwUqLMqiH2c/giphy.gif" alt="The outlet where views render" width="960" />
+
+Vue Router renders the matched component into a `<router-view />` tag. Think of it as a slot in your layout that gets swapped out depending on the current URL.
+
+In `src/App.vue`:
+
+```vue
+<template>
+  <nav>
+    <router-link to="/">Home</router-link>
+    <router-link to="/about">About</router-link>
+  </nav>
+
+  <router-view />
+</template>
+```
+
+`<router-link>` renders as an `<a>` tag but intercepts the click to do client-side navigation. It also automatically adds an `active` class when the route matches — useful for highlighting the current nav item.
+
+`<router-view />` is where the matched component appears. When you navigate to `/about`, the `AboutView` component renders here.
+
+---
+
+## Dynamic Route Segments
+
+<img src="https://media0.giphy.com/media/xT0xeuOy2Fcl9vDGiA/giphy.gif" alt="Dynamic routes — one path, many destinations" width="960" />
+
+Static routes are fine for pages that don't change. But most apps have detail pages — a city view, a user profile, a blog post. These need dynamic segments.
+
+A colon (`:`) in a route path marks a dynamic segment:
+
+```js
+const routes = [
+  { path: '/', component: HomeView },
+  { path: '/city/:id', component: CityView },
+]
+```
+
+Now `/city/atlanta`, `/city/new-york`, and `/city/seattle` all match the same route. The matched value is available inside `CityView` via `useRoute`:
+
+```vue
+<script setup>
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const cityId = route.params.id   // 'atlanta', 'new-york', etc.
+</script>
+
+<template>
+  <h1>Weather for {{ cityId }}</h1>
+</template>
+```
+
+`useRoute()` returns a reactive object representing the current route. `route.params` holds the dynamic segments, `route.query` holds URL query params (`?unit=C`), and `route.path` is the full path string.
+
+---
+
+## Programmatic Navigation with `useRouter`
+
+<img src="https://media0.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif" alt="Navigating programmatically" width="960" />
+
+`router-link` covers declarative navigation. For code-driven navigation — after a form submit, after an API call, on a button click — use `useRouter`:
+
+```vue
+<script setup>
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function goToCity(id) {
+  router.push(`/city/${id}`)
+}
+
+function goBack() {
+  router.back()
+}
+</script>
+
+<template>
+  <button @click="goToCity('seattle')">View Seattle</button>
+  <button @click="goBack()">Back</button>
+</template>
+```
+
+`router.push()` adds a new entry to the history stack — the back button returns to the previous page. `router.replace()` swaps the current entry instead, so the back button skips over the current page. Use `replace` for redirects.
+
+You can also pass an object instead of a string path:
+
+```js
+router.push({ name: 'city', params: { id: 'seattle' } })
+```
+
+Named routes (`name: 'city'` in your route config) make programmatic navigation more refactor-safe than hardcoded strings.
+
+---
+
+## Navigation Guards
+
+<img src="https://media0.giphy.com/media/OK27wINdQS5YQ/giphy.gif" alt="Guards at the gate" width="960" />
+
+Navigation guards let you run logic before a route change completes — checking authentication, logging analytics, or redirecting based on app state.
+
+The global `beforeEach` guard runs before every navigation:
+
+```js
+router.beforeEach((to, from) => {
+  const isAuthenticated = !!localStorage.getItem('token')
+
+  if (to.meta.requiresAuth && !isAuthenticated) {
+    return { path: '/login' }   // redirect to login
+  }
+  // return nothing or true to allow the navigation
+})
+```
+
+Mark protected routes with `meta`:
+
+```js
+const routes = [
+  { path: '/', component: HomeView },
+  { path: '/dashboard', component: DashboardView, meta: { requiresAuth: true } },
+  { path: '/login', component: LoginView },
+]
+```
+
+Guards receive the destination route (`to`) and the origin route (`from`). Return a route location to redirect, return `false` to cancel, or return nothing to allow.
+
+---
+
+## Seeing It All Together
+
+<img src="https://media0.giphy.com/media/13HgwGsXF0aiGY/giphy.gif" alt="All the pieces clicking into place" width="960" />
+
+Here's a mini router config for the weather dashboard we've been building toward:
+
+```js
+// src/router/index.js
+import { createRouter, createWebHistory } from 'vue-router'
+
+const routes = [
+  {
+    path: '/',
+    component: () => import('../views/DashboardView.vue'),
+  },
+  {
+    path: '/city/:id',
+    name: 'city',
+    component: () => import('../views/CityView.vue'),
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    component: () => import('../views/NotFoundView.vue'),
+  },
+]
+
+export default createRouter({
+  history: createWebHistory(),
+  routes,
+})
+```
+
+A few things to note here:
+- `() => import(...)` is lazy loading — Vue only downloads a view's code when the user navigates to it, keeping the initial bundle small.
+- `/:pathMatch(.*)*` is the catch-all 404 route — it matches anything that didn't match above.
+
+And the city detail view:
+
+```vue
+<!-- src/views/CityView.vue -->
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route  = useRoute()
+const router = useRouter()
+
+const cityId = computed(() => route.params.id)
+</script>
+
+<template>
+  <button @click="router.back()">← Back to Dashboard</button>
+  <h1>{{ cityId }}</h1>
+  <!-- weather data would render here -->
+</template>
+```
+
+---
+
+## The Mental Model
+
+<img src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbG1hNWV0YW9qZ25lMnQzNGxpdGY4bDltOXF3a21seXJkMmMzNnVwMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/65ATdpi3clAdjomZ39/giphy.gif" alt="Building the mental model" width="960" />
+
+- **Route config** → maps URL paths to components
+- **`router-view`** → the outlet where matched components render
+- **`router-link`** → declarative navigation that stays in sync with the active route
+- **`useRouter`** → programmatic navigation from inside `<script setup>`
+- **`useRoute`** → read the current URL's params, query, and path
+- **Guards** → intercept navigation to check conditions before allowing or redirecting
+
+---
+
+## Your Turn
+
+Before moving to Article 5, try this:
+
+1. Add a named route for `/city/:id` and navigate to it from a list using `router.push({ name: 'city', params: { id } })`
+2. Add a `query` param like `?unit=C` and read it with `route.query.unit`
+3. Add a `beforeEach` guard that logs `"Navigating to: <path>"` for every route change
+
+If you can do all three, you understand how Vue Router fits into a real application.
+
+---
+
+## What's Next
+
+<img src="https://media0.giphy.com/media/wR4bJk4jF5Tl6/giphy.gif" alt="What's next in the series" width="960" />
+
+In **Article 6**, we bring it all together — building out the full weather dashboard using everything from the series: reactive state, components, and routing working as one.
+
+You know how to move between pages. Now let's build what lives on them.
+
+---
+
+*This is Part 4 of the Vue 3 Fundamentals series. Sources: [Vue Router Official Docs](https://router.vuejs.org/guide/), [Vue Router — Dynamic Route Matching](https://router.vuejs.org/guide/essentials/dynamic-matching.html).*

--- a/src/content/blog/Reactivity-in-Vue3-How-Vue-Makes-Your-UI-Feel-Alive.md
+++ b/src/content/blog/Reactivity-in-Vue3-How-Vue-Makes-Your-UI-Feel-Alive.md
@@ -105,7 +105,7 @@ This is fundamentally different from vanilla JavaScript, where you'd have to man
 
 ## `ref`: Your Primary Reactivity Tool
 
-<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzU4MnFnajU1Z292dWptNnpkdjZtaTJ6ZHcxYWF1cG96Y3dmMGQzayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oDyDSmr7StLCBKucHM/giphy.gif" alt="ref — your go-to reactive tool" width="960" />
+<img src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHE4N3M4NXVkd3hua2F2M3NzandzNzAzaTIzZ202YnFrYWI1eGIzNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/bcrOR2stk6tKIxqPOZ/giphy.gif" alt="ref — your go-to reactive tool" width="960" />
 
 The most common way to create reactive state in Vue 3 is `ref`:
 

--- a/src/content/blog/Reactivity-in-Vue3-How-Vue-Makes-Your-UI-Feel-Alive.md
+++ b/src/content/blog/Reactivity-in-Vue3-How-Vue-Makes-Your-UI-Feel-Alive.md
@@ -9,7 +9,7 @@ image: {
     src: "/images/blog_covers/Vue3 Image.png",
     alt: "Vue.js logo on a light blue background with geometric shapes"
 }
-publishDate: "2026-04-09 00:00"
+publishDate: "2026-04-08 00:00"
 category: "Vue, JavaScript, Tutorials"
 tags: [vue3, javascript, frontend, tutorial, reactivity, composition-api]
 keywords: [Vue 3 reactivity, ref vs reactive, computed properties Vue 3, Vue watch, watchEffect, Vue 3 reactivity system, Composition API reactivity, Vue 3 tutorial]

--- a/src/content/blog/Vue3-Components-Building-Reusable-UI-Blocks.md
+++ b/src/content/blog/Vue3-Components-Building-Reusable-UI-Blocks.md
@@ -1,0 +1,381 @@
+---
+draft: false
+seoTitle: "Vue 3 Components: Building Reusable UI Blocks | Nerando Johnson"
+seoDescription: "Learn how Vue 3 Single-File Components work — props, events, scoped styles, and the props-down events-up pattern for building a real weather dashboard."
+author: "Nerando Johnson"
+title: "Vue 3 Components: Building Reusable UI Blocks"
+snippet: "Every Vue app is a tree of components. In this article we break down SFCs, defineProps, defineEmits, and the props-down events-up pattern that keeps data flow predictable — using a weather dashboard as our domain."
+image: {
+    src: "/images/blog_covers/Vue3 Image.png",
+    alt: "Vue.js logo on a light blue background with geometric shapes"
+}
+publishDate: "2026-04-15 00:00"
+category: "Vue, JavaScript, Tutorials"
+tags: [vue3, javascript, frontend, tutorial, components, composition-api]
+keywords: [Vue 3 components, defineProps, defineEmits, SFC, props down events up, Vue component communication, scoped styles, Vue 3 tutorial, Vue component basics, Composition API]
+series:
+  name: "Vue 3 Fundamentals"
+  order: 4
+
+# GEO-Enhanced Fields
+schema: {
+  type: "TechArticle",
+  about: "Vue 3 Single-File Components — props, events, and component communication patterns",
+  genre: "Educational Tutorial",
+  educationalLevel: "Beginner",
+  teaches: ["Single-File Components", "defineProps", "defineEmits", "Props Down Events Up", "Scoped Styles", "v-for with Components"],
+  audience: {
+    type: "ProfessionalAudience",
+    audienceType: "Frontend Developers and JavaScript Learners"
+  }
+}
+
+entities: {
+  primary: ["Vue.js", "Vue 3", "Single-File Components"],
+  secondary: ["defineProps", "defineEmits", "script setup", "scoped styles", "Composition API"],
+  people: ["Evan You"],
+  organizations: ["Vue.js Core Team", "Vue School"],
+  tools: ["Vue 3", "Vite", "VS Code", "Volar"],
+  concepts: ["Component-Based Architecture", "Props", "Custom Events", "Data Flow", "Scoped CSS", "Reusability"]
+}
+
+contentStructure: {
+  type: "Conceptual + Practical Tutorial",
+  difficulty: "Beginner",
+  timeToComplete: "10-12 minutes read",
+  prerequisites: ["Basic HTML", "Basic JavaScript", "Article 2 — Your First Vue 3 App", "Article 3 — Reactivity in Vue 3"],
+  outcomes: ["Understand the Vue Single-File Component model", "Use defineProps to pass data into a component", "Use defineEmits to send events back to the parent", "Apply scoped styles to isolate component CSS", "Organize components for a real app"]
+}
+
+semanticContext: {
+  topic: "Building and composing Vue 3 components using the Composition API",
+  subtopics: ["SFC structure", "defineProps macro", "defineEmits macro", "props-down events-up", "scoped styles", "component organization"],
+  relatedConcepts: ["React props and callbacks", "Web Components", "Angular inputs and outputs", "Component-Driven Development"],
+  practicalApplication: true
+}
+
+citationMetadata: {
+  citableAs: "Johnson, N. (2026). Vue 3 Components: Building Reusable UI Blocks",
+  lastReviewed: "2026-04-15",
+  version: "1.0",
+  originalPublisher: "Nerando Johnson's Blog"
+}
+
+aiOptimization: {
+  summaryPrompt: "This article teaches Vue 3 component fundamentals to beginners using a weather dashboard domain. It covers what a Single-File Component is, how to import and use components, how to pass data with defineProps, how to communicate back up with defineEmits, how scoped styles work, and how to organize a components folder.",
+  keyTakeaways: [
+    "A Vue Single-File Component (SFC) combines template, script setup, and scoped styles in one .vue file",
+    "Imported components in script setup are automatically available in the template — no registration needed",
+    "defineProps declares what data a component expects from its parent; defineEmits declares what events it can fire",
+    "Props flow downward (parent to child); events flow upward (child to parent) — this is the core data flow pattern in Vue",
+    "Children should never directly mutate props — emit an event and let the parent update its own state",
+    "The scoped attribute on style blocks prevents CSS from leaking into other components"
+  ],
+  technicalDepth: "low",
+  codeExamples: true
+}
+---
+
+
+## Vue 3 Components: Building Reusable UI Blocks
+
+*Part 4 of the **Vue 3 Fundamentals** series — understanding SFCs, props, and component events.*
+
+---
+
+Every Vue application is a tree of components.
+
+At the root, you have `App.vue`. Underneath it, you have everything else — your header, your search bar, your individual weather cards. Each is a self-contained piece of UI with its own logic, template, and styles.
+
+This is the component model. It's how Vue (and every modern framework) manages complexity. Instead of one massive HTML file with thousands of lines of JavaScript, you break your UI into small, focused, reusable pieces.
+
+In this article, we'll look at what components are, how to build them, and how to make them talk to each other — using our weather dashboard as the domain throughout.
+
+---
+
+## What Is a Component?
+
+<img src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExM2FqcHQza3VmMWJtNWt3azNmNTdxNDkzeHQya2YzNGd5cTZtZm04ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1oGXIfkeF4P4w3zPxk/giphy.gif" alt="Breaking UI into reusable pieces" width="960" />
+
+A Vue component is a reusable, self-contained unit of UI. It encapsulates three things:
+
+- **Template** — the HTML structure
+- **Script** — the logic (data, methods, computed values)
+- **Style** — the CSS that applies to it
+
+In Vue 3, we write components as Single-File Components (SFCs) — `.vue` files that contain all three in one place:
+
+```vue
+<!-- src/components/WeatherCard.vue -->
+<script setup>
+const conditionEmoji = {
+  Sunny: '☀️',
+  Cloudy: '☁️',
+  Rainy: '🌧️',
+  Windy: '💨',
+  Snowy: '❄️',
+}
+</script>
+
+<template>
+  <div class="card">
+    <h2>Atlanta, GA</h2>
+    <p class="temp">72°F</p>
+    <p class="condition">{{ conditionEmoji['Sunny'] }} Sunny</p>
+  </div>
+</template>
+
+<style scoped>
+.card {
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: white;
+}
+.temp { font-size: 2.5rem; font-weight: bold; margin: 0.25rem 0; }
+.condition { color: #64748b; }
+</style>
+```
+
+That's a complete component. No external dependencies. Drop it anywhere in your app and it works.
+
+
+## Using a Component
+
+<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzU4MnFnajU1Z292dWptNnpkdjZtaTJ6ZHcxYWF1cG96Y3dmMGQzayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oDyDSmr7StLCBKucHM/giphy.gif" alt="Plugging components into the app" width="960" />
+
+To use `WeatherCard` in `App.vue`, import it and place it in the template:
+
+```vue
+<!-- src/App.vue -->
+<script setup>
+import WeatherCard from './components/WeatherCard.vue'
+</script>
+
+<template>
+  <main>
+    <h1>🌍 Weather Dashboard</h1>
+    <WeatherCard />
+  </main>
+</template>
+```
+
+With `<script setup>`, imported components are automatically available in the template — no registration step needed.
+
+Notice the `<WeatherCard />` syntax — Vue components use PascalCase in templates, which visually distinguishes them from native HTML elements like `<div>` and `<input>`.
+
+
+## Props: Passing Data Into a Component
+
+<img src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnVxYnlwYjRhZWI1aTdncHJoZmFob3VqcXpzcmkyZmNud2FwMWZtcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ge91zAgmwUqLMqiH2c/giphy.gif" alt="Passing data down to child components" width="960" />
+
+A component that always shows the same city and temperature isn't very useful. Props let a parent pass data into a child.
+
+Let's update `WeatherCard` to accept real city data:
+
+```vue
+<!-- src/components/WeatherCard.vue -->
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  city: {
+    type: Object,
+    required: true
+  },
+  unit: {
+    type: String,
+    default: 'F'
+  }
+})
+
+const conditionEmoji = {
+  Sunny: '☀️', Cloudy: '☁️', Rainy: '🌧️', Windy: '💨', Snowy: '❄️',
+}
+
+const displayTemp = computed(() =>
+  props.unit === 'C'
+    ? Math.round((props.city.temp - 32) * 5 / 9)
+    : props.city.temp
+)
+</script>
+
+<template>
+  <div class="card">
+    <h2>{{ city.name }}</h2>
+    <p class="temp">{{ displayTemp }}°{{ unit }}</p>
+    <p class="condition">
+      {{ conditionEmoji[city.condition] ?? '🌡️' }}
+      {{ city.condition }}
+    </p>
+    <p class="meta">💧 {{ city.humidity }}% · 💨 {{ city.wind }} mph</p>
+  </div>
+</template>
+```
+
+`defineProps` is a Vue macro — you don't import it, it's built into `<script setup>`. It declares what data the component expects to receive.
+
+Now the parent passes city data as attributes:
+
+```vue
+<WeatherCard
+  :city="{ id: 1, name: 'Atlanta, GA', temp: 72, condition: 'Sunny', humidity: 45, wind: 8 }"
+  unit="F"
+/>
+```
+
+Props flow **downward** — from parent to child. A child component should never directly modify the props it receives. If you need to signal a change back, the child communicates upward through events.
+
+
+## Events: Sending Data Back Up
+
+<img src="https://media0.giphy.com/media/xT0xeuOy2Fcl9vDGiA/giphy.gif" alt="Events flowing back up to the parent" width="960" />
+
+When something happens inside a child — a button click, a user removing a city — the child emits an event and the parent listens for it.
+
+Let's add a "Remove" button to `WeatherCard`:
+
+```vue
+<!-- src/components/WeatherCard.vue -->
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  city: { type: Object, required: true },
+  unit: { type: String, default: 'F' }
+})
+
+const emit = defineEmits(['remove'])
+
+const conditionEmoji = { Sunny: '☀️', Cloudy: '☁️', Rainy: '🌧️', Windy: '💨', Snowy: '❄️' }
+
+const displayTemp = computed(() =>
+  props.unit === 'C'
+    ? Math.round((props.city.temp - 32) * 5 / 9)
+    : props.city.temp
+)
+</script>
+
+<template>
+  <div class="card">
+    <header>
+      <h2>{{ city.name }}</h2>
+      <button class="remove-btn" @click="emit('remove', city.id)">✕</button>
+    </header>
+    <p class="temp">{{ displayTemp }}°{{ unit }}</p>
+    <p class="condition">{{ conditionEmoji[city.condition] ?? '🌡️' }} {{ city.condition }}</p>
+    <p class="meta">💧 {{ city.humidity }}% · 💨 {{ city.wind }} mph</p>
+  </div>
+</template>
+```
+
+`defineEmits` declares what events this component can fire. When the remove button is clicked, we emit `'remove'` with the city's `id` as the payload.
+
+The parent listens with `@event-name`:
+
+```vue
+<!-- src/App.vue -->
+<script setup>
+import { ref } from 'vue'
+import WeatherCard from './components/WeatherCard.vue'
+
+const cities = ref([
+  { id: 1, name: 'Atlanta, GA',  temp: 72, condition: 'Sunny',  humidity: 45, wind: 8  },
+  { id: 2, name: 'New York, NY', temp: 61, condition: 'Cloudy', humidity: 60, wind: 12 },
+])
+const unit = ref('F')
+
+function removeCity(id) {
+  cities.value = cities.value.filter(c => c.id !== id)
+}
+</script>
+
+<template>
+  <main>
+    <WeatherCard
+      v-for="city in cities"
+      :key="city.id"
+      :city="city"
+      :unit="unit"
+      @remove="removeCity"
+    />
+  </main>
+</template>
+```
+
+This is the **props down, events up** pattern. The parent owns the data. The child only reports what happened. Data flow stays predictable and components stay decoupled.
+
+
+## Scoped Styles
+
+<img src="https://media0.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif" alt="Styles that stay in their lane" width="960" />
+
+The `scoped` attribute on `<style>` means the styles in a component only apply to that component's HTML:
+
+```vue
+<style scoped>
+/* This .card class won't affect any other .card elements in the app */
+.card {
+  background: linear-gradient(135deg, #f0f9ff, #e0f2fe);
+  border-radius: 12px;
+}
+</style>
+```
+
+Vue achieves this by adding a unique data attribute to the component's elements at compile time. No naming collisions, no specificity battles between components.
+
+
+## Component Organization
+
+<img src="https://media0.giphy.com/media/OK27wINdQS5YQ/giphy.gif" alt="Keeping things organized" width="960" />
+
+As your app grows, keep your components folder organized by responsibility:
+
+```
+src/
+└── components/
+    ├── WeatherCard.vue     → Individual city weather card
+    ├── WeatherSearch.vue   → City search input + add button
+    └── UnitToggle.vue      → °F / °C switcher
+```
+
+Each component has one clear job. `WeatherCard` displays weather for one city. `WeatherSearch` handles the search/add flow. `UnitToggle` switches the temperature unit. None of them need to know what the others are doing.
+
+That separation makes each component independently testable — and means you can update one without risking breaking the others.
+
+
+## The Mental Model
+
+<img src="https://media0.giphy.com/media/13HgwGsXF0aiGY/giphy.gif" alt="The full picture coming together" width="960" />
+
+- **SFC** → one `.vue` file = template + script + scoped styles
+- **`defineProps`** → declare what data flows in from the parent
+- **`defineEmits`** → declare what events flow out to the parent
+- **Props down, events up** → the rule that keeps data flow predictable
+- **Scoped styles** → CSS that stays in its lane
+
+
+## Your Turn
+
+<img src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbG1hNWV0YW9qZ25lMnQzNGxpdGY4bDltOXF3a21seXJkMmMzNnVwMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/65ATdpi3clAdjomZ39/giphy.gif" alt="Your turn" width="960" />
+
+Try these before moving to Article 5:
+
+1. Create a `UnitToggle.vue` component that emits a `'toggle'` event when clicked
+2. In `App.vue`, listen to `@toggle` and flip the `unit` ref between `'F'` and `'C'`
+3. Pass the updated `unit` as a prop to each `WeatherCard` and watch all the temperatures update at once
+
+If all three work — you've just implemented the entire props-down events-up pattern on a real feature.
+
+
+## What's Next
+
+<img src="https://media0.giphy.com/media/wR4bJk4jF5Tl6/giphy.gif" alt="What's next" width="960" />
+
+In **Article 5**, we wire up Vue Router — turning our single-view dashboard into a navigable multi-page application with dynamic route segments, `router-link`, and `useRouter`.
+
+Progress over perfection. Let's go.
+
+---
+
+*This is Part 4 of the Vue 3 Fundamentals series. Sources: [Vue.js Component Basics](https://vuejs.org/guide/essentials/component-basics), [Vue School — Vue Component Fundamentals with the Composition API](https://vueschool.io/articles/vuejs-tutorials/vue-component-fundamentals-with-the-composition-api/).*


### PR DESCRIPTION
Adds two new articles to the Vue 3 Fundamentals series and corrects a Part/Article number mismatch in the Vue Router post where the body referenced "Part 4" but `series.order` was 5.

## Changes

- **New — Part 4:** `Vue3-Components-Building-Reusable-UI-Blocks.md` — SFCs, props, emits, scoped styles; weather dashboard as running example
- **New — Part 5:** `Finding-Your-Route-Mastering-Vue-Router.md` — Vue Router setup, `router-view`/`router-link`, dynamic segments, `useRoute`/`useRouter`, navigation guards
- **Fix:** Body intro, "Your Turn" CTA, and footer in the Vue Router article all corrected to "Part 5" / "Article 6" to align with `series.order: 5`
- **Update:** `Reactivity-in-Vue3-How-Vue-Makes-Your-UI-Feel-Alive.md` — adjusted `publishDate` and replaced GIF